### PR TITLE
Fix error on loading dbd.mysql with MySQL 5.5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-10-16  Katsuyuki Tateishi  <kt@wheel.jp>
+
+	* Fix: error on loading dbd.mysql with MySQL 5.5.
+
 2014-06-26  Tatsuya BIZENN  <bizenn@visha.org>
 
 	* Fix: improper initialization: add my_init() calling and drop

--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,10 @@ AC_CHECK_DECLS([MY_CS_AVAILABLE],,,[
 #include <my_sys.h>
 ])
 
+AC_CHECK_FUNC([get_charset_number],
+	      [AC_DEFINE([HAVE_MYSQL_GET_CHARSET_NUMBER],[1],
+			 [Define to 1 if you have linkable get_charset_number])])
+
 dnl Creating gpd (gauche package description) file
 GAUCHE_PACKAGE_CONFIGURE_ARGS="`echo ""$ac_configure_args"" | sed 's/[\\""\`\$]/\\\&/g'`"
 AC_MSG_NOTICE([creating ${PACKAGE_NAME}.gpd])

--- a/dbd_mysqllib.stub
+++ b/dbd_mysqllib.stub
@@ -735,7 +735,13 @@
 #endif
 "
 (define-cproc mysql-get-charset-number (csname::<const-cstring>)
-  (expr <int> "GET_CHARSET_NUMBER(csname)"))
+  (expr <int> "
+#if HAVE_MYSQL_GET_CHARSET_NUMBER
+   GET_CHARSET_NUMBER(csname)
+#else
+   0 /* Zero means no charset found */
+#endif
+"))
 ;;
 ;; from errmsg.h mysql-5.0.27
 ;;


### PR DESCRIPTION
When this module is build with MySQL (or MariaDB) 5.5, following error occured
on (use dbd.mysql) and this commit fix it:

  **\* ERROR: Compile Error: failed to link ./dbd_mysql.so dynamically: \
   ./dbd_mysql.so: undefined symbol: get_charset_number
