### PR TITLE
Fix error on fetching MYSQL_TIME_TYPE fields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2014-10-18  Katsuyuki Tateishi <kt@wheel.jp>
+
+	* Fix: error on fetching MYSQL_TIME_TYPE field
+
+	* Change: string format for DATETIME is changed to 'YYYY-MM-DD
+	  HH:DD:SS' from 'YYYY-MM-DD HH:DD:SS.FFFFFF' when FFFFFF, fractional
+	  seconds, is zero (in many cases this condition will be met).
+
 2014-06-26  Tatsuya BIZENN  <bizenn@visha.org>
 
 	* Fix: improper initialization: add my_init() calling and drop

--- a/dbd_mysql.c
+++ b/dbd_mysql.c
@@ -539,7 +539,8 @@ static ScmObj mysql_bind_to_scm_obj(MYSQL_BIND *bind)
 	    return Scm_MakeInteger64(*(long long int*)bind->buffer);
 	case MYSQL_TYPE_DOUBLE:
 	    return Scm_MakeFlonum(*(double*)bind->buffer);
-	case MYSQL_TYPE_DATETIME:
+	case MYSQL_TYPE_DATE: case MYSQL_TYPE_TIME:
+	case MYSQL_TYPE_DATETIME: case MYSQL_TYPE_TIMESTAMP:
 	    return Scm_MakeMysqlTime((MYSQL_TIME*)bind->buffer);
 	default:
 	    Scm_RaiseCondition(MYSQL_ERROR, "error-code", SCM_MAKE_INT(0), "sql-code", SCM_MAKE_STR_IMMUTABLE(""),

--- a/dbd_mysql.h
+++ b/dbd_mysql.h
@@ -209,6 +209,7 @@ extern void mysql_res_cleanup(ScmObj obj);
 #  define MYSQL_TIME_SECOND(obj)   (MYSQL_TIME_UNBOX(obj).second)
 #  define MYSQL_TIME_NEGATIVE_P(obj) (MYSQL_TIME_UNBOX(obj).neg)
 #  define MYSQL_TIME_SECOND_PART(obj) (MYSQL_TIME_UNBOX(obj).second_part)
+#  define MYSQL_TIME_TIME_TYPE(obj) (MYSQL_TIME_UNBOX(obj).time_type)
 
    extern ScmObj mysql_time_allocate(ScmClass *klass, ScmObj initargs);
    extern ScmObj Scm_MakeMysqlTime(MYSQL_TIME *time);

--- a/dbd_mysqllib.stub
+++ b/dbd_mysqllib.stub
@@ -712,6 +712,16 @@
     (begin
       (define-type <mysql-time> "ScmMysqlTime*" "MySQL DATE/TIME/TIMESTAMP structure"
 	"MYSQL_TIME_P" "SCM_MYSQL_TIME")
+      (define-enum MYSQL_TIMESTAMP_NONE)
+      (define-constant MYSQL_TIMESTAMP_NONE (c "SCM_MAKE_INT(MYSQL_TIMESTAMP_NONE)"))
+      (define-enum MYSQL_TIMESTAMP_ERROR)
+      (define-constant MYSQL_TIMESTAMP_ERROR (c "SCM_MAKE_INT(MYSQL_TIMESTAMP_ERROR)"))
+      (define-enum MYSQL_TIMESTAMP_DATE)
+      (define-constant MYSQL_TIMESTAMP_DATE (c "SCM_MAKE_INT(MYSQL_TIMESTAMP_DATE)"))
+      (define-enum MYSQL_TIMESTAMP_DATETIME)
+      (define-constant MYSQL_TIMESTAMP_DATETIME (c "SCM_MAKE_INT(MYSQL_TIMESTAMP_DATETIME)"))
+      (define-enum MYSQL_TIMESTAMP_TIME)
+      (define-constant MYSQL_TIMESTAMP_TIME (c "SCM_MAKE_INT(MYSQL_TIMESTAMP_TIME)"))
       (define-cclass <mysql-time>
 	"ScmMysqlTime*" "Scm_MysqlTimeClass"
 	()
@@ -722,6 +732,7 @@
 	 (minute :type <uint> :c-spec "MYSQL_TIME_MINUTE(obj)")
 	 (second :type <uint> :c-spec "MYSQL_TIME_SECOND(obj)")
 	 (second-part :type <uint> :c-spec "MYSQL_TIME_SECOND_PART(obj)") ; microsecond/unused
+	 (time-type :type <uint> :c-spec "MYSQL_TIME_TIME_TYPE(obj)")
 	 (nagative? :type <boolean> :c-spec "MYSQL_TIME_NEGATIVE_P(obj)"))
 	(allocator (c "mysql_time_allocate")))
       (define-cproc mysql-time? (obj)


### PR DESCRIPTION
Fetching MYSQL_TIME_TYPE family fields except DATETIME fails with;

  **\* MYSQL-ERROR: Unsupported type: 10

This commit fix this problem.  This also changes string format for
DATETIME from 'YYYY-MM-DD HH:DD:SS.FFFFFF' to 'YYYY-MM-DD HH:DD:SS'
when FFFFFF, fractional seconds, is zero.  Before MySQL 5.6.4 accept
fractional seconds but don't store them, so it would be useful change
for many cases.
